### PR TITLE
Implement a JUnit Reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
         "commander": "^2.16.0",
         "cosmiconfig": "^5.0.5",
         "debug": "^3.1.0",
-        "is-ci": "^1.1.0"
+        "is-ci": "^1.1.0",
+        "xml-escape": "^1.1.0"
     },
     "engines": {
         "node": ">=8.9.0"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,9 +7,9 @@ export default (): number => {
         .version(process.env.STRICTER_VERSION as string)
         .option('-c, --config <path>', 'specify config location')
         .option(
-            '-r, --reporter <console|mocha>',
+            '-r, --reporter <console|mocha|junit>',
             'specify reporter',
-            /^(console|mocha)$/i,
+            /^(console|mocha|junit)$/i,
             'console',
         )
         .parse(process.argv);

--- a/src/logger/__snapshots__/junit.test.ts.snap
+++ b/src/logger/__snapshots__/junit.test.ts.snap
@@ -5,15 +5,19 @@ exports[`junitLogger outputs valid complex xml 1`] = `
     <testsuites package=\\"stricter\\">
         <testsuite name=\\"stricter\\" failures=\\"5\\" errors=\\"3\\" tests=\\"3\\">
     <testcase name=\\"rule1\\">
-    <failure type=\\"error\\" message=\\"Rule error\\"><![CDATA[error1]]></failure>
-<failure type=\\"error\\" message=\\"Rule error\\"><![CDATA[someting 'that' \\"needs\\" <escaping> and closes it's CDATA ]]]]><![CDATA[> early]]></failure>
+    <failure type=\\"error\\"><![CDATA[
+error1
+someting 'that' \\"needs\\" <escaping> and closes it's CDATA ]]]]><![CDATA[> early]]></failure>
 </testcase>
 <testcase name=\\"rule2\\">
-    <failure type=\\"warning\\" message=\\"Rule warning\\"><![CDATA[rule2-warning]]></failure>
+    <failure type=\\"warning\\"><![CDATA[
+rule2-warning]]></failure>
 </testcase>
 <testcase name=\\"rule3\\">
-    <failure type=\\"error\\" message=\\"Rule error\\"><![CDATA[rule3-error]]></failure>
-<failure type=\\"warning\\" message=\\"Rule warning\\"><![CDATA[rule3-warning]]></failure>
+    <failure type=\\"error\\"><![CDATA[
+rule3-error]]></failure>
+<failure type=\\"warning\\"><![CDATA[
+rule3-warning]]></failure>
 </testcase>
 </testsuite>
     </testsuites>"

--- a/src/logger/__snapshots__/junit.test.ts.snap
+++ b/src/logger/__snapshots__/junit.test.ts.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`junitLogger outputs valid complex xml 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
+    <testsuites package=\\"stricter\\">
+        <testsuite name=\\"stricter\\" failures=\\"5\\" errors=\\"3\\" tests=\\"3\\">
+    <testcase name=\\"rule1\\">
+    <failure type=\\"error\\" message=\\"Rule error\\"><![CDATA[error1]]></failure>
+<failure type=\\"error\\" message=\\"Rule error\\"><![CDATA[someting 'that' \\"needs\\" <escaping>]]></failure>
+</testcase>
+<testcase name=\\"rule2\\">
+    <failure type=\\"warning\\" message=\\"Rule warning\\"><![CDATA[rule2-warning]]></failure>
+</testcase>
+<testcase name=\\"rule3\\">
+    <failure type=\\"error\\" message=\\"Rule error\\"><![CDATA[rule3-error]]></failure>
+<failure type=\\"warning\\" message=\\"Rule warning\\"><![CDATA[rule3-warning]]></failure>
+</testcase>
+</testsuite>
+    </testsuites>"
+`;
+
+exports[`junitLogger outputs valid empty xml 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
+    <testsuites package=\\"stricter\\">
+        <testsuite name=\\"stricter\\" failures=\\"0\\" errors=\\"0\\" tests=\\"1\\">
+    <testcase name=\\"no errors\\">
+    
+</testcase>
+</testsuite>
+    </testsuites>"
+`;

--- a/src/logger/__snapshots__/junit.test.ts.snap
+++ b/src/logger/__snapshots__/junit.test.ts.snap
@@ -6,7 +6,7 @@ exports[`junitLogger outputs valid complex xml 1`] = `
         <testsuite name=\\"stricter\\" failures=\\"5\\" errors=\\"3\\" tests=\\"3\\">
     <testcase name=\\"rule1\\">
     <failure type=\\"error\\" message=\\"Rule error\\"><![CDATA[error1]]></failure>
-<failure type=\\"error\\" message=\\"Rule error\\"><![CDATA[someting 'that' \\"needs\\" <escaping>]]></failure>
+<failure type=\\"error\\" message=\\"Rule error\\"><![CDATA[someting 'that' \\"needs\\" <escaping> and closes it's CDATA ]]]]><![CDATA[> early]]></failure>
 </testcase>
 <testcase name=\\"rule2\\">
     <failure type=\\"warning\\" message=\\"Rule warning\\"><![CDATA[rule2-warning]]></failure>

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -2,6 +2,7 @@ import { LogEntry } from './../types';
 
 export { default as consoleLogger } from './console';
 export { default as mochaLogger } from './mocha';
+export { default as junitLogger } from './junit';
 export { compactProjectLogs } from './flatten';
 export const getErrorCount = (projectLogs: LogEntry[]) =>
     Object.values(projectLogs).reduce((acc, i) => acc + ((i.errors && i.errors.length) || 0), 0);

--- a/src/logger/junit.test.ts
+++ b/src/logger/junit.test.ts
@@ -16,7 +16,13 @@ describe('junitLogger', () => {
 
     it('outputs valid complex xml', () => {
         logJunit([
-            { rule: 'rule1', errors: ['error1', `someting 'that' "needs" <escaping>`] },
+            {
+                rule: 'rule1',
+                errors: [
+                    'error1',
+                    `someting 'that' "needs" <escaping> and closes it's CDATA ]]> early`,
+                ],
+            },
             { rule: 'rule2', warnings: ['rule2-warning'] },
             { rule: 'rule3', errors: ['rule3-error'], warnings: ['rule3-warning'] },
         ]);

--- a/src/logger/junit.test.ts
+++ b/src/logger/junit.test.ts
@@ -1,0 +1,26 @@
+import logJunit from './junit';
+
+describe('junitLogger', () => {
+    const logMock = jest.fn();
+    console.log = logMock;
+
+    beforeEach(() => {
+        logMock.mockReset();
+    });
+
+    it('outputs valid empty xml', () => {
+        logJunit([]);
+        const output = logMock.mock.calls[0][0];
+        expect(output).toMatchSnapshot();
+    });
+
+    it('outputs valid complex xml', () => {
+        logJunit([
+            { rule: 'rule1', errors: ['error1', `someting 'that' "needs" <escaping>`] },
+            { rule: 'rule2', warnings: ['rule2-warning'] },
+            { rule: 'rule3', errors: ['rule3-error'], warnings: ['rule3-warning'] },
+        ]);
+        const output = logMock.mock.calls[0][0];
+        expect(output).toMatchSnapshot();
+    });
+});

--- a/src/logger/junit.ts
+++ b/src/logger/junit.ts
@@ -13,6 +13,12 @@ interface ReportData {
     rules: { [rule: string]: string[] };
 }
 
+// According to https://en.wikipedia.org/wiki/CDATA#Nesting this is how you escape the CDATA end
+// sequence in CDATA
+const escapeCDATA = (cdata: string): string => {
+    return cdata.replace(/\]\]\>/g, ']]]]><![CDATA[>');
+};
+
 const reportTemplate = (suite: string) => `<?xml version="1.0" encoding="utf-8"?>
     <testsuites package="stricter">
         ${suite}
@@ -36,7 +42,7 @@ const testcaseTemplate = (name: string, failures: string) => `<testcase name="${
 
 const testcaseFailure = (type: Level, message: string, detail: string = '') =>
     `<failure type="${type}" message="${xmlEscape(message)}">${
-        detail !== '' ? `<![CDATA[${detail}]]>` : ''
+        detail !== '' ? `<![CDATA[${escapeCDATA(detail)}]]>` : ''
     }</failure>`;
 
 export default (logs: LogEntry[]): void => {

--- a/src/logger/junit.ts
+++ b/src/logger/junit.ts
@@ -41,8 +41,11 @@ const testcaseTemplate = (name: string, failures: string) => `<testcase name="${
 </testcase>`;
 
 const testcaseFailure = (type: Level, message: string, detail: string = '') =>
-    `<failure type="${type}" message="${xmlEscape(message)}">${
-        detail !== '' ? `<![CDATA[${escapeCDATA(detail)}]]>` : ''
+    `<failure type="${type}"${message !== '' ? ` message="${xmlEscape(message)}"` : ''}>${
+        detail !== ''
+            ? `<![CDATA[
+${escapeCDATA(detail)}]]>`
+            : ''
     }</failure>`;
 
 export default (logs: LogEntry[]): void => {
@@ -54,16 +57,12 @@ export default (logs: LogEntry[]): void => {
             if (log.errors) {
                 acc.failures += log.errors.length;
                 acc.errors += log.errors.length;
-                log.errors.forEach(error =>
-                    acc.rules[log.rule].push(testcaseFailure(Level.ERROR, 'Rule error', error)),
-                );
+                acc.rules[log.rule].push(testcaseFailure(Level.ERROR, '', log.errors.join('\n')));
             }
             if (log.warnings) {
                 acc.failures += log.warnings.length;
-                log.warnings.forEach(warning =>
-                    acc.rules[log.rule].push(
-                        testcaseFailure(Level.WARNING, 'Rule warning', warning),
-                    ),
+                acc.rules[log.rule].push(
+                    testcaseFailure(Level.WARNING, '', log.warnings.join('\n')),
                 );
             }
             acc.tests += 1;

--- a/src/logger/junit.ts
+++ b/src/logger/junit.ts
@@ -55,7 +55,9 @@ export default (logs: LogEntry[]): void => {
             if (log.warnings) {
                 acc.failures += log.warnings.length;
                 log.warnings.forEach(warning =>
-                    acc.rules[log.rule].push(testcaseFailure(Level.WARNING, 'Rule warning', warning)),
+                    acc.rules[log.rule].push(
+                        testcaseFailure(Level.WARNING, 'Rule warning', warning),
+                    ),
                 );
             }
             acc.tests += 1;

--- a/src/logger/junit.ts
+++ b/src/logger/junit.ts
@@ -1,0 +1,82 @@
+import { LogEntry } from './../types';
+import xmlEscape = require('xml-escape');
+
+enum Level {
+    WARNING = 'warning',
+    ERROR = 'error',
+}
+
+interface ReportData {
+    failures: number;
+    errors: number;
+    tests: number;
+    rules: { [rule: string]: string[] };
+}
+
+const reportTemplate = (suite: string) => `<?xml version="1.0" encoding="utf-8"?>
+    <testsuites package="stricter">
+        ${suite}
+    </testsuites>`;
+
+const suiteTemplate = (
+    name: string,
+    failureCount: number,
+    errors: number,
+    tests: number,
+    testcases: string[],
+) => `<testsuite name="${xmlEscape(
+    name,
+)}" failures="${failureCount}" errors="${errors}" tests="${tests}">
+    ${testcases.join('\n')}
+</testsuite>`;
+
+const testcaseTemplate = (name: string, failures: string) => `<testcase name="${xmlEscape(name)}">
+    ${failures}
+</testcase>`;
+
+const testcaseFailure = (type: Level, message: string, detail: string = '') =>
+    `<failure type="${type}" message="${xmlEscape(message)}">${
+        detail !== '' ? `<![CDATA[${detail}]]>` : ''
+    }</failure>`;
+
+export default (logs: LogEntry[]): void => {
+    const data: ReportData = logs.reduce(
+        (acc: ReportData, log) => {
+            if (!acc.rules.hasOwnProperty(log.rule)) {
+                acc.rules[log.rule] = [];
+            }
+            if (log.errors) {
+                acc.failures += log.errors.length;
+                acc.errors += log.errors.length;
+                log.errors.forEach(error =>
+                    acc.rules[log.rule].push(testcaseFailure(Level.ERROR, 'Rule error', error)),
+                );
+            }
+            if (log.warnings) {
+                acc.failures += log.warnings.length;
+                log.warnings.forEach(warning =>
+                    acc.rules[log.rule].push(testcaseFailure(Level.WARNING, 'Rule warning', warning)),
+                );
+            }
+            acc.tests += 1;
+            return acc;
+        },
+        { failures: 0, errors: 0, tests: 0, rules: {} },
+    );
+
+    const testcases = Object.keys(data.rules).map(rule =>
+        testcaseTemplate(rule, data.rules[rule].join('\n')),
+    );
+
+    // the JUnit format isn't really designed for a system that doesn't log success, so if we don't
+    // have any warnings or failures we still need a dummy testcase so that there's something to parse
+    if (testcases.length === 0) {
+        data.tests = 1;
+        testcases.push(testcaseTemplate('no errors', ''));
+    }
+    const xml = reportTemplate(
+        suiteTemplate('stricter', data.failures, data.errors, data.tests, testcases),
+    );
+
+    console.log(xml);
+};

--- a/src/stricter.ts
+++ b/src/stricter.ts
@@ -1,7 +1,13 @@
 import { getConfig } from './config';
 import { getRuleDefinitions, getRuleApplications, filterFilesToProcess } from './rule';
 import { applyProjectRules, readFilesData } from './processor';
-import { consoleLogger, mochaLogger, compactProjectLogs, getErrorCount } from './logger';
+import {
+    consoleLogger,
+    junitLogger,
+    mochaLogger,
+    compactProjectLogs,
+    getErrorCount,
+} from './logger';
 import { listFiles } from './utils';
 import { StricterArguments, Reporter } from './types';
 import debug, { measure } from './debug';
@@ -47,6 +53,8 @@ export default ({
         measure('Write logs', () => {
             if (reporter === Reporter.MOCHA) {
                 mochaLogger(logs);
+            } else if (reporter === Reporter.JUNIT) {
+                junitLogger(logs);
             } else {
                 consoleLogger(logs);
             }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,6 +13,7 @@ export enum Level {
 
 export enum Reporter {
     CONSOLE = 'console',
+    JUNIT = 'junit',
     MOCHA = 'mocha',
 }
 

--- a/types/missing.d.ts
+++ b/types/missing.d.ts
@@ -4,6 +4,7 @@ declare module 'is-ci' {
     var isCi: boolean;
     export = isCi;
 }
-
-
-
+declare module 'xml-escape' {
+    function xmlEscape(str: string, ignore?: string): string;
+    export = xmlEscape;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4818,6 +4818,10 @@ ws@^1.1.1:
     options ">=0.0.5"
     ultron "1.0.x"
 
+xml-escape@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/xml-escape/-/xml-escape-1.1.0.tgz#3904c143fa8eb3a0030ec646d2902a2f1b706c44"
+
 xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"


### PR DESCRIPTION
I've added a JUnit reporter. The JUnit format isn't really suited to output from a tool like Stricter, it's designed for reporting on tests and testcases, whereas that doesn't really work with Stricter. Still, from the point of view of getting Stricter output into Bamboo it does the job.

Here's what it looks like when it fails http://go.atlassian.com/stricter-bamboo-example (private link)

The `Rule error` is the "message", and the bit before it is the "detail" (or body of the tag). That's about as good as you'll get out of the JUnit.

Ideally Stricter would support a bit more structured log messages than a string - in particular splitting the "error" from "detail" would provide for nicer reporting. But that'd be a major change, so I'll leave that out of scope.

Please excuse any TypeScript faux pas', it's one of my first times really using it. I tried to keep it in the same style as the existing code.
