### PR TITLE
Allow `rulesDir` config to be an array of directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master
 
 - Dependencies bump
+- Allow `rulesDir` to accept an array of folders
 
 ## 0.3.1 - New year, new release
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ module.exports = {
 ```
 
 ## Description
-`root` - root folder for the project.
+`root` - `string`, root folder for the project.
 
-`rulesDir` - folder, containing custom rules. Rule files need to follow naming convention `<rulename>.rule.js`. They will be available for configuration as `<rulename>`.
+`rulesDir` - `string | string[]`, folder(s), containing custom rules. Rule files need to follow naming convention `<rulename>.rule.js`. They will be available for configuration as `<rulename>`.
 
 `exclude` - `RegExp | RegExp[] | Function`, regular expressions to exclude files, uses relative path from root or function accepting relative path and returning boolean
 

--- a/src/rule-resolver/get-rule-definitions.ts
+++ b/src/rule-resolver/get-rule-definitions.ts
@@ -10,12 +10,17 @@ const stripOutSuffix = (str: string): string => {
     return str.substring(0, str.length - RULE_SUFFIX.length);
 };
 
-export default (rules: ConfigRules, rulesDir?: string | undefined): RuleDefinitions => {
+export default (rules: ConfigRules, rulesDir?: string | string[] | undefined): RuleDefinitions => {
     const rulesToResolve = Object.keys(rules);
     let allRulesResolved: RuleDefinitions = {};
 
     if (rulesDir) {
-        const customRuleFiles = listFiles(rulesDir).filter(i => i.endsWith(RULE_SUFFIX));
+        const rulesDirArr = Array.isArray(rulesDir) ? rulesDir : [rulesDir];
+
+        const customRuleFiles = rulesDirArr.reduce(
+            (acc, dir) => [...acc, ...listFiles(dir).filter(i => i.endsWith(RULE_SUFFIX))],
+            [] as string[],
+        );
         allRulesResolved = customRuleFiles.reduce(
             (acc, filePath: string) => {
                 const ruleName = stripOutSuffix(path.basename(filePath));

--- a/src/rule-resolver/index.ts
+++ b/src/rule-resolver/index.ts
@@ -5,7 +5,7 @@ import getRuleDefinitions from './get-rule-definitions';
 
 export default (
     rules: ConfigRules,
-    rulesDir: string | undefined,
+    rulesDir: string | string[] | undefined,
     rulesToVerify: string[] | undefined,
 ): RuleApplications => {
     const ruleDefinitions = getRuleDefinitions(rules, rulesDir);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,7 +38,7 @@ export interface ConfigRules {
 
 export interface Config {
     root: string;
-    rulesDir?: string;
+    rulesDir?: string | string[];
     exclude?: FileFilter;
     rules: ConfigRules;
 }


### PR DESCRIPTION
This opens up the possibility of sourcing rules from third parties or npm packages without implementing plugin support.

Even though we will probably implement plugin support in the future, I can't see any downsides to letting stricter accept multiple rules directories until plugins exist.