### PR TITLE
Add plugin support for rule definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,21 +14,26 @@ yarn add stricter --dev
 ```
 
 # Usage
+
 ```
 yarn stricter
 ```
+
 You can run `yarn stricter --help` for help.
 
 # Configuration
+
 Stricter uses `stricter.config.js` to read configuration.
 The configuration file will be resolved starting from the current working directory location, and searching up the file tree until a config file is (or isn't) found.
 
 ## Sample configuration
+
 ```javascript
 module.exports = {
     root: 'src',
     rulesDir: 'rules',
     exclude: /\.DS_Store/,
+    plugins: ['tangerine'],
     rules: {
         'hello-world-project': {
             level: 'error'
@@ -51,27 +56,36 @@ module.exports = {
                 ]
             }
         }],
+        'tangerine/project-structure': {
+            level: 'error',
+            config: { ... },
+        }
     }
 }
 
 ```
 
 ## Description
+
 `root` - `string`, root folder for the project.
 
 `rulesDir` - `string | string[]`, folder(s), containing custom rules. Rule files need to follow naming convention `<rulename>.rule.js`. They will be available for configuration as `<rulename>`.
 
 `exclude` - `RegExp | RegExp[] | Function`, regular expressions to exclude files, uses relative path from root or function accepting relative path and returning boolean
 
+`plugins` - `string[]`, packages that contain third-party rule definitions that you can use in `rules`. See [Plugins](#Plugins) for more details.
+
 `rules` - an object, containing configuration for rules:
-  - `level` - `error | warning | off`, log level
-  - `include` - `RegExp | RegExp[] | Function`, regular expressions to match files, uses relative path from root or function accepting relative path and returning boolean
-  - `exclude` - `RegExp | RegExp[] | Function`, regular expressions to exclude from matched files, uses relative path from root or function accepting relative path and returning boolean
-  - `config` - `any`, config to be passed into rule
+
+-   `level` - `error | warning | off`, log level
+-   `include` - `RegExp | RegExp[] | Function`, regular expressions to match files, uses relative path from root or function accepting relative path and returning boolean
+-   `exclude` - `RegExp | RegExp[] | Function`, regular expressions to exclude from matched files, uses relative path from root or function accepting relative path and returning boolean
+-   `config` - `any`, config to be passed into rule
 
 # Default rules
 
 ## stricter/circular-dependencies
+
 Checks for circular dependencies in the code. Has a configuration to additionally check for cycles on folder level.
 
 ```
@@ -83,7 +97,8 @@ Checks for circular dependencies in the code. Has a configuration to additionall
 ```
 
 ## stricter/unused-files
-Checks for unused files. 
+
+Checks for unused files.
 `entry` - application entry points. Usually these files are mentioned in `entry` part of webpack config or they are non-js files you want to keep (configs, markdown, etc.)
 `relatedEntry` - related entry points, they are considered used only if any of its dependencies are used by an `entry` or its transitive dependencies. Usually these are tests and storybooks.
 
@@ -97,7 +112,9 @@ Checks for unused files.
 ```
 
 # Custom rules
+
 A rule is a javascript module that exports an object that implements the following interface
+
 ```typescript
 interface RuleDefinition {
     onProject: ({
@@ -118,6 +135,7 @@ interface RuleDefinition {
     }) => string[];
 }
 ```
+
 `onProject` will be called once with `files` and `dependencies` calculated for current project.
 
 `rootPath` is an absolute path to project root.
@@ -131,6 +149,7 @@ interface RuleDefinition {
 `exclude` value of `exclude` from the rule
 
 # CLI
+
 ```
 Options:
   --help          Show help                                            [boolean]
@@ -141,9 +160,109 @@ Options:
   --clearCache    Clears cache
 ```
 
+# Plugins
+
+Stricter supports consuming rule definitions from other packages by specifying them in the `plugins` field of your stricter config.
+
+The package names of plugins must be named `stricter-plugin-<name>`, e.g. `stricter-plugin-tangerine`. This guarantees unique
+rule names across different plugins.
+
+## Configuration
+
+In the `plugins` field, you can specify the plugin using its short name `<name>` or its long form `stricter-plugin-<name>`. You can then
+enable and configure rules from a plugin by specifying the rules in the `rules` field. Note that each rule of the plugin will be namespaced by the
+plugin name `<name>/<ruleName>` when used by the consumer of the plugin, e.g. `tangerine/project-structure`.
+
+e.g.
+
+```js
+// stricter.config.js
+module.exports = {
+    root: '.',
+    plugins: ['tangerine'],
+    rules: {
+        'tangerine/project-structure': {
+            level: 'error',
+            config: {...},
+        }
+    }
+}
+```
+
+## Creating plugins
+
+To create a stricter plugin, export a `rules` key that contains the rule definitions you wish to provide.
+
+e.g.
+
+```js
+module.exports = {
+    rules: {
+        'project-structure': {
+            onProject: (...) => {...}
+        },
+        'another-rule': {
+            onProject: (...) => {...}
+        }
+    }
+}
+```
+
+The rules should not be prefixed with the plugin name when defined by the package, only consumers of the package should reference them with their fully qualified name.
+
+Also ensure the package name starts with `stricter-plugin` otherwise it won't be able to be loaded.
+
+## Pre-configured plugin rules
+
+Rules provided by a plugin do not enable those rules by default. If you would like to provide a preset configuration of rules provided by your plugin, simply export your preset configuration under a certain key. Consumers can then import that configuration and spread it into the `rules` field of their stricter config.
+
+E.g.
+
+### Plugin
+
+```js
+// stricter-plugin-tangerine/index.js
+module.exports = {
+    config: {
+        'tangerine/project-structure': {
+            level: 'error',
+            config: {
+                '.': {
+                    'package.json': { type: 'file' },
+                    'src': { type: 'dir' }
+                }
+            }
+        }
+    },
+    rules: {
+        'project-structure': {
+            onProject: (...) => {...}
+        },
+    }
+}
+```
+
+### Stricter config
+
+```js
+// stricter.config.js
+
+const { config: tangerineConfig } = require('stricter-plugin-tangerine');
+
+module.exports = {
+    root: '.',
+    plugins: ['tangerine'],
+    rules: {
+        ...tangerineConfig,
+    },
+};
+```
+
 # Debugging
+
 It helps to use `src/debug.ts` as an entry point for debugging.
 A sample launch.json for VS Code might look like
+
 ```json
 {
     "version": "0.2.0",

--- a/README.md
+++ b/README.md
@@ -170,8 +170,9 @@ rule names across different plugins.
 ## Configuration
 
 In the `plugins` field, you can specify the plugin using its short name `<name>` or its long form `stricter-plugin-<name>`. You can then
-enable and configure rules from a plugin by specifying the rules in the `rules` field. Note that each rule of the plugin will be namespaced by the
-plugin name `<name>/<ruleName>` when used by the consumer of the plugin, e.g. `tangerine/project-structure`.
+enable and configure rules from a plugin by specifying the rules in the `rules` field.
+
+When configuring rules from a plugin, they must be prefixed by their short plugin name `<name>/<ruleName>`, e.g. `tangerine/project-structure`.
 
 e.g.
 
@@ -191,7 +192,9 @@ module.exports = {
 
 ## Creating plugins
 
-To create a stricter plugin, export a `rules` key that contains the rule definitions you wish to provide.
+To create a stricter plugin, ensure the package name is of the format `stricter-plugin-<name>`.
+
+The main file of the package should then export a `rules` key that contains the rule definitions you wish to provide.
 
 e.g.
 
@@ -208,13 +211,11 @@ module.exports = {
 }
 ```
 
-The rules should not be prefixed with the plugin name when defined by the package, only consumers of the package should reference them with their fully qualified name.
-
-Also ensure the package name starts with `stricter-plugin` otherwise it won't be able to be loaded.
+Note that the rule names should not be prefixed when defining them inside the plugin, they are only prefixed when specifying them in configuration.
 
 ## Pre-configured plugin rules
 
-Rules provided by a plugin do not enable those rules by default. If you would like to provide a preset configuration of rules provided by your plugin, simply export your preset configuration under a certain key. Consumers can then import that configuration and spread it into the `rules` field of their stricter config.
+Rules provided by a plugin are not enabled by default, they must be configured by the end-user. If you would like to provide a preset configuration of rules provided by your plugin, simply export your preset configuration under a certain key. Consumers can then import that configuration and spread it into the `rules` field of their stricter config.
 
 E.g.
 
@@ -223,6 +224,7 @@ E.g.
 ```js
 // stricter-plugin-tangerine/index.js
 module.exports = {
+    // This key can be arbitrarily named
     config: {
         'tangerine/project-structure': {
             level: 'error',
@@ -247,6 +249,7 @@ module.exports = {
 ```js
 // stricter.config.js
 
+// This import key `config` must match what is exported by the plugin
 const { config: tangerineConfig } = require('stricter-plugin-tangerine');
 
 module.exports = {

--- a/src/config/process-config.test.ts
+++ b/src/config/process-config.test.ts
@@ -98,4 +98,18 @@ describe('processConfig', () => {
 
         expect(result.exclude).toBe(exclude);
     });
+
+    it('populates plugins', () => {
+        const plugins = ['abc'];
+        const result = processConfig({
+            config: {
+                plugins,
+                root: 'test',
+                rules: {},
+            },
+            filePath: '',
+        });
+
+        expect(result.plugins).toBe(plugins);
+    });
 });

--- a/src/config/process-config.ts
+++ b/src/config/process-config.ts
@@ -23,5 +23,9 @@ export default (foundConfig: ConfigFile): Config => {
         result.exclude = config.exclude;
     }
 
+    if (config.plugins) {
+        result.plugins = config.plugins;
+    }
+
     return result;
 };

--- a/src/integration-tests/stricter.test.ts
+++ b/src/integration-tests/stricter.test.ts
@@ -125,4 +125,74 @@ describe('Stricter', () => {
         );
         expect(console.log).toHaveBeenNthCalledWith(3, '2 errors');
     });
+
+    describe('plugins', () => {
+        it('should add rule definitions available to be used in `rules`', () => {
+            const ruleSpy = jest.fn(() => []);
+            jest.doMock(
+                'stricter-plugin-abc',
+                () => ({
+                    rules: {
+                        'some-rule': {
+                            onProject: ruleSpy,
+                        },
+                    },
+                }),
+                { virtual: true },
+            );
+            jest.doMock(stricterConfigPath, () => ({
+                root: 'project/src',
+                rulesDir: 'project/rules',
+                rules: {
+                    'abc/some-rule': [
+                        {
+                            level: 'error',
+                        },
+                    ],
+                },
+                plugins: ['abc'],
+            }));
+            const stricter = getStricter({
+                config: stricterConfigPath,
+                reporter: undefined,
+                rulesToVerify: undefined,
+                clearCache: undefined,
+            });
+            stricter();
+            expect(console.log).toHaveBeenCalledTimes(1);
+            expect(console.log).toHaveBeenCalledWith('No errors');
+            expect(ruleSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not enable rules by default', () => {
+            const ruleSpy = jest.fn(() => []);
+            jest.doMock(
+                'stricter-plugin-abc',
+                () => ({
+                    rules: {
+                        'some-rule': {
+                            onProject: ruleSpy,
+                        },
+                    },
+                }),
+                { virtual: true },
+            );
+            jest.doMock(stricterConfigPath, () => ({
+                root: 'project/src',
+                rulesDir: 'project/rules',
+                rules: {},
+                plugins: ['abc'],
+            }));
+            const stricter = getStricter({
+                config: stricterConfigPath,
+                reporter: undefined,
+                rulesToVerify: undefined,
+                clearCache: undefined,
+            });
+            stricter();
+            expect(console.log).toHaveBeenCalledTimes(1);
+            expect(console.log).toHaveBeenCalledWith('No errors');
+            expect(ruleSpy).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/src/rule-resolver/get-plugin-rule-definitions.test.ts
+++ b/src/rule-resolver/get-plugin-rule-definitions.test.ts
@@ -1,0 +1,92 @@
+import getPluginRuleDefinitions from './get-plugin-rule-definitions';
+import { RuleDefinition } from '../types';
+
+describe('getPluginRuleDefinitions', () => {
+    let rule1: RuleDefinition;
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.resetModules();
+        rule1 = {
+            onProject: jest.fn(),
+        };
+        jest.doMock(
+            'stricter-plugin-abc',
+            () => ({
+                rules: {
+                    'rule-1': rule1,
+                },
+            }),
+            { virtual: true },
+        );
+    });
+
+    it('should return the rules from a single plugin', () => {
+        const rules = getPluginRuleDefinitions(['abc']);
+
+        expect(rules).toEqual({
+            'abc/rule-1': rule1,
+        });
+    });
+    it('should return the rules from multiple plugins', () => {
+        const rule2 = {
+            onProject: jest.fn(),
+        };
+        jest.doMock(
+            'stricter-plugin-def',
+            () => ({
+                rules: {
+                    'rule-2': rule2,
+                },
+            }),
+            { virtual: true },
+        );
+        const rules = getPluginRuleDefinitions(['abc', 'def']);
+
+        expect(rules).toEqual({
+            'abc/rule-1': rule1,
+            'def/rule-2': rule2,
+        });
+    });
+    it('should prefix each rule name with the plugin name', () => {
+        const rules = getPluginRuleDefinitions(['abc']);
+
+        expect(Object.keys(rules)[0]).toEqual(expect.stringMatching('^abc/'));
+    });
+    it('should work with plugin names specified by full plugin module name', () => {
+        const rules = getPluginRuleDefinitions(['stricter-plugin-abc']);
+
+        expect(rules).toEqual({
+            'abc/rule-1': rule1,
+        });
+    });
+    it('should throw if the plugin cannot be resolved', () => {
+        expect(() => {
+            getPluginRuleDefinitions(['does-not-exist']);
+        }).toThrowErrorMatchingInlineSnapshot(
+            `"Could not resolve plugin stricter-plugin-does-not-exist"`,
+        );
+    });
+    it('should throw if plugin is missing rules', () => {
+        jest.doMock('stricter-plugin-abc', () => ({}), { virtual: true });
+        expect(() => {
+            getPluginRuleDefinitions(['abc']);
+        }).toThrowErrorMatchingInlineSnapshot(
+            `"Plugin stricter-plugin-abc is missing rules export"`,
+        );
+    });
+    it('should throw if plugin has an invalid rule definition', () => {
+        jest.doMock(
+            'stricter-plugin-abc',
+            () => ({
+                rules: {
+                    'rule-1': { missing: 'onProject' },
+                },
+            }),
+            { virtual: true },
+        );
+        expect(() => {
+            getPluginRuleDefinitions(['abc']);
+        }).toThrowErrorMatchingInlineSnapshot(`"Invalid rule definition: abc/rule-1"`);
+    });
+    it.todo('should work with scoped package plugin names');
+});

--- a/src/rule-resolver/get-plugin-rule-definitions.ts
+++ b/src/rule-resolver/get-plugin-rule-definitions.ts
@@ -1,0 +1,55 @@
+import { RuleDefinitions, RuleDefinition } from '../types';
+
+const pluginPrefix = 'stricter-plugin-';
+
+const isValidRule = (rule: { [props: string]: any }): rule is RuleDefinition => {
+    return typeof rule.onProject === 'function';
+};
+
+const normalisePluginName = (pluginName: string) => {
+    const shortPluginName = pluginName.replace(pluginPrefix, '');
+    const longPluginName = `${pluginPrefix}${shortPluginName}`;
+
+    return { shortPluginName, longPluginName };
+};
+
+const retrievePluginRules = (pluginName: string): RuleDefinitions => {
+    const rules: RuleDefinitions = {};
+    const { longPluginName, shortPluginName } = normalisePluginName(pluginName);
+    let pluginModule: { [key: string]: any };
+    try {
+        pluginModule = require(longPluginName);
+    } catch (e) {
+        if (e.code === 'MODULE_NOT_FOUND') {
+            throw new Error(`Could not resolve plugin ${longPluginName}`);
+        }
+        throw e;
+    }
+
+    if (!pluginModule.rules) {
+        throw new Error(`Plugin ${longPluginName} is missing rules export`);
+    }
+    Object.entries<{ [props: string]: unknown }>(pluginModule.rules).forEach(
+        ([ruleName, ruleDef]) => {
+            const qualifiedRuleName = `${shortPluginName}/${ruleName}`;
+            if (!isValidRule(ruleDef)) {
+                throw new Error(`Invalid rule definition: ${qualifiedRuleName}`);
+            }
+            rules[qualifiedRuleName] = ruleDef;
+        },
+    );
+    return rules;
+};
+
+export default (pluginNames: string[]): RuleDefinitions => {
+    return pluginNames.reduce(
+        (acc, pluginName) => {
+            const pluginRules = retrievePluginRules(pluginName);
+            return {
+                ...acc,
+                ...pluginRules,
+            };
+        },
+        {} as RuleDefinitions,
+    );
+};

--- a/src/rule-resolver/get-rule-definitions.ts
+++ b/src/rule-resolver/get-rule-definitions.ts
@@ -3,6 +3,7 @@ import { EOL } from 'os';
 import { listFiles } from './../utils';
 import { RuleDefinitions, ConfigRules } from './../types';
 import defaultRules from '../default-rules';
+import getPluginRuleDefinitions from './get-plugin-rule-definitions';
 
 export const RULE_SUFFIX = '.rule.js';
 
@@ -10,7 +11,11 @@ const stripOutSuffix = (str: string): string => {
     return str.substring(0, str.length - RULE_SUFFIX.length);
 };
 
-export default (rules: ConfigRules, rulesDir?: string | string[] | undefined): RuleDefinitions => {
+export default (
+    rules: ConfigRules,
+    rulesDir?: string | string[] | undefined,
+    pluginNames?: string[] | undefined,
+): RuleDefinitions => {
     const rulesToResolve = Object.keys(rules);
     let allRulesResolved: RuleDefinitions = {};
 
@@ -43,7 +48,11 @@ export default (rules: ConfigRules, rulesDir?: string | string[] | undefined): R
         );
     }
 
-    allRulesResolved = Object.entries(defaultRules).reduce((acc, [ruleName, rule]) => {
+    const pluginRules = pluginNames ? getPluginRuleDefinitions(pluginNames) : {};
+
+    const externalRules = { ...defaultRules, ...pluginRules };
+
+    allRulesResolved = Object.entries(externalRules).reduce((acc, [ruleName, rule]) => {
         if (!rulesToResolve.includes(ruleName)) {
             return acc;
         }

--- a/src/rule-resolver/index.ts
+++ b/src/rule-resolver/index.ts
@@ -6,9 +6,10 @@ import getRuleDefinitions from './get-rule-definitions';
 export default (
     rules: ConfigRules,
     rulesDir: string | string[] | undefined,
+    pluginNames: string[] | undefined,
     rulesToVerify: string[] | undefined,
 ): RuleApplications => {
-    const ruleDefinitions = getRuleDefinitions(rules, rulesDir);
+    const ruleDefinitions = getRuleDefinitions(rules, rulesDir, pluginNames);
     const filteredRuleDefinitions = filterRuleDefinitions(ruleDefinitions, rulesToVerify);
     const ruleApplications = getRuleApplications(rules, filteredRuleDefinitions, rulesToVerify);
 

--- a/src/rule-resolver/test.ts
+++ b/src/rule-resolver/test.ts
@@ -22,10 +22,11 @@ afterEach(() => {
 
 describe('ruleResolver', () => {
     it('should invoke child functions', () => {
-        ruleResolver({}, undefined, undefined);
+        ruleResolver({}, 'rules-dir', ['plugin-1'], undefined);
 
         expect(getRuleApplicationsMock.mock.calls.length).toBe(1);
         expect(filterRuleDefinitionsMock.mock.calls.length).toBe(1);
         expect(getRuleDefinitionsMock.mock.calls.length).toBe(1);
+        expect(getRuleDefinitionsMock).toHaveBeenCalledWith({}, 'rules-dir', ['plugin-1']);
     });
 });

--- a/src/stricter.ts
+++ b/src/stricter.ts
@@ -37,7 +37,12 @@ export default ({
     const filesData = processFiles(filesToProcess, cacheManager);
 
     debug('Get rules');
-    const ruleApplications = resolveRules(config.rules, config.rulesDir, rulesToVerify);
+    const ruleApplications = resolveRules(
+        config.rules,
+        config.rulesDir,
+        config.plugins,
+        rulesToVerify,
+    );
 
     debug('Apply rules');
     const projectResult = processRules(config.root, filesData, ruleApplications);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -34,11 +34,18 @@ export interface ConfigRules {
     [ruleName: string]: RuleUsage | RuleUsage[];
 }
 
+export interface Plugin {
+    rules: {
+        [ruleName: string]: RuleDefinition;
+    };
+}
+
 export interface Config {
     root: string;
     rulesDir?: string | string[];
     exclude?: FileFilter;
     rules: ConfigRules;
+    plugins?: string[];
 }
 
 export interface FileData {


### PR DESCRIPTION
 This adds plugin support for rule definitions, similar to eslint.

Support for scoped packages (i.e. '@scope/stricter-plugin-xxx') is *not* supported yet. Some additional work is required to support that, which I'm happy to add, just thought I'd leave it for another PR or at least after initial review.

I need to update the README as well to explain how plugins work.