### PR TITLE
Better packages support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Master
 
-- Add function variant of `rules` to support execution over multiple packages
+- Add new way of configuring rules via a function to support execution over multiple packages
 
 ## 0.3.2 - Plugins
 

--- a/README.md
+++ b/README.md
@@ -75,21 +75,23 @@ module.exports = {
 
 `plugins` - `string[]`, packages that contain third-party rule definitions that you can use in `rules`. See [Plugins](#Plugins) for more details.
 
-`rules` - required, an object or a function returning an object, containing configuration for rules:
+`rules` - required, an object containing configuration for rules.
+
+The keys should be rule names and values should be an object, array of objects or a function. Arrays will result in the rule being executed once per each entry in the array, see [rule functions](#rule-functions) for more info on that syntax. The objects (`RuleObject`) should be of the form:
 
 -   `level` - `error | warning | off`, log level
 -   `include` - `RegExp | RegExp[] | Function`, regular expressions to match files, uses relative path from root or function accepting relative path and returning boolean
 -   `exclude` - `RegExp | RegExp[] | Function`, regular expressions to exclude from matched files, uses relative path from root or function accepting relative path and returning boolean
 -   `config` - `any`, config to be passed into rule
 
-`packages` - `string[]`, an array of globs that match paths to packages if you are in a multi-package repo. This can be used to override the default list of packages that are provided to `rules` if using its [function variant](#rules-function).
+`packages` - `string[]`, an array of globs that match paths to packages if you are in a multi-package repo. This can be used to override the default list of packages that are provided to rules configured using a [function](#rule-functions).
 
-### `rules` function
+### Rule functions
 
-The default way of configuring rules is to provide an object, however, the `rules` field may also be a function that returns an object instead.
+The default way of configuring rules is to provide objects, however, each rule value may also be a function that returns an object instead.
 This provides an easy way to configure rules designed to be executed against each package separately in a monorepo.
 
-Signature: `(args: { packages: string[] }) => RulesObject`
+Signature: `(args: { packages: string[] }) => RuleObject | RuleObject[]`
 
 where `packages` is a list of package directory paths in your project that are automatically detected by searching for package.json's in sub-directories, i.e. `*/**/package.json`.
 To override where `packages` are searched, you can use the top-level `packages` config to provide an array of globs instead. For example, this could be sourced from the yarn workspaces field in your project's root package.json.
@@ -99,8 +101,8 @@ E.g.
 ```js
 module.exports = {
     ...
-    rules: ({ packages }) => ({
-        'package-structure': packages.map(pkg => ({
+    rules: {
+        'package-structure': ({ packages }) => packages.map(pkg => ({
             level: 'error',
             config: {
                 pkgRoot: pkg,
@@ -110,13 +112,13 @@ module.exports = {
             level: 'error',
             ...
         }
-    }),
+    },
     ...
 }
 ```
 
 Here, the `package-structure` rule enforces a specific structure for a package and takes the root path of the package as a config argument. In a single-package repo, the `rule` can just use the object syntax and specify the root path of the project as the package root.
-However, in a multi-package repo this rule should be executed against each package separately rather than once at the root of the project.
+However, in a multi-package repo this rule should be executed against each package separately rather than once at the root of the project so the function syntax can be used.
 
 # Default rules
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "lint": "tslint --project .",
         "typecheck": "tsc --noEmit",
         "build:types": "tsc --emitDeclarationOnly --declarationDir lib --declaration",
-        "generate:schema": "typescript-json-schema tsconfig.json ConfigAPI --include src/types/* --out src/config/config-schema.json --noExtraProps --required --useTypeOfKeyword",
+        "generate:schema": "typescript-json-schema tsconfig.json Config --include src/types/* --out src/config/config-schema.json --noExtraProps --required --useTypeOfKeyword",
         "all": "yarn generate:schema && concurrently npm:build:main npm:build:types npm:lint npm:typecheck -c green,yellow,blue",
         "test": "jest",
         "report-coverage": "coveralls < coverage/lcov.info"

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,12 +1,20 @@
 import { Config } from './../types';
+import preprocessConfig from './preprocess-config';
 import processConfig from './process-config';
 import readConfig from './read-config';
 import validateConfig from './validate-config';
 
 export const getConfig = (configPath?: string): Config => {
     const foundConfig = readConfig(configPath);
-    validateConfig(foundConfig);
-    const processedConfig = processConfig(foundConfig);
+    const preprocessedConfig = {
+        ...foundConfig,
+        config: foundConfig && foundConfig.config ? preprocessConfig(foundConfig) : undefined,
+    };
+    if (validateConfig(preprocessedConfig)) {
+        const processedConfig = processConfig(preprocessedConfig);
+        return processedConfig;
+    }
 
-    return processedConfig;
+    // This will never be hit since validateConfig throws if it does not return true
+    throw Error('Invalid config');
 };

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,4 +1,4 @@
-import { Config } from './../types';
+import { Config, ValidatedConfigFile } from './../types';
 import preprocessConfig from './preprocess-config';
 import processConfig from './process-config';
 import readConfig from './read-config';
@@ -10,11 +10,8 @@ export const getConfig = (configPath?: string): Config => {
         ...foundConfig,
         config: foundConfig && foundConfig.config ? preprocessConfig(foundConfig) : undefined,
     };
-    if (validateConfig(preprocessedConfig)) {
-        const processedConfig = processConfig(preprocessedConfig);
-        return processedConfig;
-    }
+    validateConfig(preprocessedConfig);
 
-    // This will never be hit since validateConfig throws if it does not return true
-    throw Error('Invalid config');
+    const processedConfig = processConfig(preprocessedConfig as ValidatedConfigFile);
+    return processedConfig;
 };

--- a/src/config/preprocess-config.test.ts
+++ b/src/config/preprocess-config.test.ts
@@ -1,0 +1,239 @@
+import * as path from 'path';
+import fastGlob from 'fast-glob';
+import preprocessConfig from './preprocess-config';
+
+jest.mock('path');
+jest.mock('fast-glob');
+
+describe('preprocessConfig', () => {
+    beforeAll(() => {
+        const { resolve } = require('path');
+        jest.restoreAllMocks();
+        resolve.mockImplementation((_: string, dir: string) => `resolved_${dir}`);
+    });
+
+    it('resolves root to a full path', () => {
+        const result = preprocessConfig({
+            config: {
+                root: 'test',
+                rules: {},
+            },
+            filePath: '',
+        });
+
+        expect(result.root).toBe('resolved_test');
+        expect(result.rules).toEqual({});
+    });
+
+    it('does not modify non-function rules', () => {
+        const rules = {
+            foo: {
+                include: [/foo/],
+            },
+            bar: [
+                {
+                    include: [/bar/],
+                },
+                {
+                    include: [/baz/],
+                },
+            ],
+        };
+        const result = preprocessConfig({
+            config: {
+                rules,
+                root: 'test',
+            },
+            filePath: '',
+        });
+
+        expect(result.rules).toEqual(rules);
+    });
+
+    it('keeps other config props', () => {
+        const result = preprocessConfig({
+            config: {
+                root: 'test',
+                rules: {},
+                rulesDir: 'testdir',
+                exclude: /exclude/,
+                plugins: ['foo'],
+                packages: ['packages/**'],
+            },
+            filePath: '',
+        });
+        expect(result).toMatchObject({
+            rulesDir: 'testdir',
+            exclude: /exclude/,
+            plugins: ['foo'],
+            packages: ['packages/**'],
+        });
+    });
+
+    it('resolves rules functions', () => {
+        const fastGlobSpy = jest
+            .spyOn(fastGlob, 'sync')
+            .mockImplementation(() => ['foo/package.json', 'bar/package.json']);
+        const dirnameSpy = jest
+            .spyOn(path, 'dirname')
+            .mockImplementation((path: string) => path.split('/')[0]);
+
+        const result = preprocessConfig({
+            config: {
+                root: 'test',
+                rules: {
+                    'my-rule': ({ packages }) =>
+                        packages.map(pkg => ({
+                            include: [new RegExp(`${pkg}/.*\.js`)],
+                        })),
+                    'another-pkg-rule': ({ packages }) =>
+                        packages.map(pkg => ({
+                            exclude: [new RegExp(`${pkg}/.*\.js`)],
+                        })),
+                    'normal-rule': {
+                        include: /another/,
+                    },
+                },
+            },
+            filePath: '',
+        });
+
+        expect(fastGlobSpy).toHaveBeenCalledWith(['*/**/package.json', '!**/node_modules/**'], {
+            cwd: 'resolved_test',
+        });
+
+        expect(result.rules).toEqual({
+            'my-rule': [
+                {
+                    include: [/foo\/.*.js/],
+                },
+                {
+                    include: [/bar\/.*.js/],
+                },
+            ],
+            'another-pkg-rule': [
+                {
+                    exclude: [/foo\/.*.js/],
+                },
+                {
+                    exclude: [/bar\/.*.js/],
+                },
+            ],
+            'normal-rule': {
+                include: /another/,
+            },
+        });
+
+        fastGlobSpy.mockRestore();
+        dirnameSpy.mockRestore();
+    });
+
+    it('resolves rules functions with custom packages arg', () => {
+        const fastGlobSpy = jest
+            .spyOn(fastGlob, 'sync')
+            .mockImplementation(() => ['foo/package.json']);
+        const dirnameSpy = jest
+            .spyOn(path, 'dirname')
+            .mockImplementation((path: string) => path.split('/')[0]);
+
+        const result = preprocessConfig({
+            config: {
+                root: 'test',
+                rules: {
+                    'my-rule': ({ packages }) =>
+                        packages.map(pkg => ({
+                            include: [new RegExp(`${pkg}/.*\.js`)],
+                        })),
+                    'another-pkg-rule': ({ packages }) =>
+                        packages.map(pkg => ({
+                            exclude: [new RegExp(`${pkg}/.*\.js`)],
+                        })),
+                    'normal-rule': {
+                        include: /another/,
+                    },
+                },
+                packages: ['f*'],
+            },
+            filePath: '',
+        });
+
+        expect(fastGlobSpy).toHaveBeenCalledWith(['f*/package.json', '!**/node_modules/**'], {
+            cwd: 'resolved_test',
+        });
+
+        expect(result.rules).toEqual({
+            'my-rule': [
+                {
+                    include: [/foo\/.*.js/],
+                },
+            ],
+            'another-pkg-rule': [
+                {
+                    exclude: [/foo\/.*.js/],
+                },
+            ],
+            'normal-rule': {
+                include: /another/,
+            },
+        });
+
+        fastGlobSpy.mockRestore();
+        dirnameSpy.mockRestore();
+    });
+
+    it('should not coerce invalid rule types to an object', () => {
+        const invalidRulesFn: any = () => {};
+        const fnResult = preprocessConfig({
+            config: {
+                root: 'test',
+                rules: invalidRulesFn,
+            },
+            filePath: '',
+        });
+
+        expect(fnResult).toEqual({
+            root: 'resolved_test',
+            rules: invalidRulesFn,
+        });
+
+        const undefinedResult = preprocessConfig({
+            config: {
+                root: 'test',
+                rules: undefined as any,
+            },
+            filePath: '',
+        });
+
+        expect(undefinedResult).toEqual({
+            root: 'resolved_test',
+            rules: undefined,
+        });
+    });
+
+    it('should only search for packages once regardless of how many rules are functions', () => {
+        const fastGlobSpy = jest
+            .spyOn(fastGlob, 'sync')
+            .mockImplementation(() => ['foo/package.json']);
+
+        preprocessConfig({
+            config: {
+                root: 'test',
+                rules: {
+                    'my-rule': ({ packages }) =>
+                        packages.map(pkg => ({
+                            include: [new RegExp(`${pkg}/.*\.js`)],
+                        })),
+                    'another-rule': ({ packages }) =>
+                        packages.map(pkg => ({
+                            include: [new RegExp(`${pkg}/.*\.js`)],
+                        })),
+                },
+            },
+            filePath: '',
+        });
+
+        expect(fastGlobSpy).toHaveBeenCalledTimes(1);
+
+        fastGlobSpy.mockRestore();
+    });
+});

--- a/src/config/preprocess-config.ts
+++ b/src/config/preprocess-config.ts
@@ -1,0 +1,55 @@
+import fastGlob from 'fast-glob';
+import path from 'path';
+import { Config, RuleUsage, ConfigFile, RuleFn, ConfigRules, ConfigAPI } from './../types';
+import { getDirResolver } from '../utils';
+
+const getRuleUsages = (
+    rulesFn: RuleFn,
+    root: string,
+    /* Cache is mutated */
+    cache: { packages?: string[] } = {},
+    packageGlobs: string[] = ['*/**'],
+): RuleUsage | RuleUsage[] => {
+    const pkgJsonGlobs = packageGlobs.map(p => `${p}/package.json`);
+    if (!cache.packages) {
+        const resolvedPackages: string[] = fastGlob
+            .sync<string>([...pkgJsonGlobs, '!**/node_modules/**'], {
+                cwd: root,
+            })
+            .map(pkgJsonPath => path.dirname(pkgJsonPath));
+        cache.packages = resolvedPackages;
+    }
+    return rulesFn({ packages: cache.packages });
+};
+
+const transformRules = (config: ConfigAPI): ConfigRules => {
+    const cache = {};
+
+    return Object.entries(config.rules).reduce(
+        (acc, [ruleName, ruleVal]) => {
+            if (typeof ruleVal === 'function') {
+                acc[ruleName] = getRuleUsages(ruleVal, config.root, cache, config.packages);
+            } else {
+                acc[ruleName] = ruleVal;
+            }
+            return acc;
+        },
+        {} as ConfigRules,
+    );
+};
+
+/**
+ * Preprocesses the configuration, converting any rule functions into rule usages.
+ *
+ * We preprocess this before validation so that we can validate the resulting rule usages.
+ */
+export default ({ config, filePath }: ConfigFile): Config => {
+    const resolveDir = getDirResolver(filePath);
+    config.root = resolveDir(config.root);
+
+    return {
+        ...config,
+        root: config.root,
+        rules: typeof config.rules === 'object' ? transformRules(config) : config.rules,
+    };
+};

--- a/src/config/process-config.test.ts
+++ b/src/config/process-config.test.ts
@@ -1,34 +1,7 @@
-import * as path from 'path';
-import fastGlob from 'fast-glob';
-import processConfig, { getDirResolver } from './process-config';
+import processConfig from './process-config';
 
 jest.mock('path');
 jest.mock('fast-glob');
-
-describe('getDirResolver', () => {
-    const mockDirname = 'mockDirname';
-
-    beforeAll(() => {
-        const { dirname, resolve } = require('path');
-
-        dirname.mockImplementation((dirName: string) => {
-            if (dirName === mockDirname) {
-                return mockDirname;
-            }
-        });
-        resolve.mockImplementation((dirName: string, dir: string) => {
-            if (dirName === mockDirname) {
-                return dir;
-            }
-        });
-    });
-
-    it('runs consmiconfig based on cwd', () => {
-        const dirResolver = getDirResolver(mockDirname);
-
-        expect(dirResolver('test')).toBe('test');
-    });
-});
 
 describe('processConfig', () => {
     beforeAll(() => {
@@ -46,7 +19,7 @@ describe('processConfig', () => {
             filePath: '',
         });
 
-        expect(result.root).toBe('resolved_test');
+        expect(result.root).toBe('test');
         expect(result.rules).toEqual({});
     });
 
@@ -115,81 +88,5 @@ describe('processConfig', () => {
         });
 
         expect(result.plugins).toBe(plugins);
-    });
-
-    it('resolves rules functions', () => {
-        const fastGlobSpy = jest
-            .spyOn(fastGlob, 'sync')
-            .mockImplementation(() => ['foo/package.json', 'bar/package.json']);
-        const dirnameSpy = jest
-            .spyOn(path, 'dirname')
-            .mockImplementation((path: string) => path.split('/')[0]);
-
-        const result = processConfig({
-            config: {
-                root: 'test',
-                rules: ({ packages }) => ({
-                    'my-rule': packages.map(pkg => ({
-                        include: [new RegExp(`${pkg}/.*\.js`)],
-                    })),
-                }),
-            },
-            filePath: '',
-        });
-
-        expect(fastGlobSpy).toHaveBeenCalledWith(['*/**/package.json', '!**/node_modules/**'], {
-            cwd: 'resolved_test',
-        });
-
-        expect(result.rules).toEqual({
-            'my-rule': [
-                {
-                    include: [/foo\/.*.js/],
-                },
-                {
-                    include: [/bar\/.*.js/],
-                },
-            ],
-        });
-
-        fastGlobSpy.mockRestore();
-        dirnameSpy.mockRestore();
-    });
-
-    it('resolves rules functions with custom packages arg', () => {
-        const fastGlobSpy = jest
-            .spyOn(fastGlob, 'sync')
-            .mockImplementation(() => ['foo/package.json']);
-        const dirnameSpy = jest
-            .spyOn(path, 'dirname')
-            .mockImplementation((path: string) => path.split('/')[0]);
-
-        const result = processConfig({
-            config: {
-                root: 'test',
-                rules: ({ packages }) => ({
-                    'my-rule': packages.map(pkg => ({
-                        include: [new RegExp(`${pkg}/.*\.js`)],
-                    })),
-                }),
-                packages: ['f*'],
-            },
-            filePath: '',
-        });
-
-        expect(fastGlobSpy).toHaveBeenCalledWith(['f*/package.json', '!**/node_modules/**'], {
-            cwd: 'resolved_test',
-        });
-
-        expect(result.rules).toEqual({
-            'my-rule': [
-                {
-                    include: [/foo\/.*.js/],
-                },
-            ],
-        });
-
-        fastGlobSpy.mockRestore();
-        dirnameSpy.mockRestore();
     });
 });

--- a/src/config/test.ts
+++ b/src/config/test.ts
@@ -1,0 +1,74 @@
+import preprocessConfig from './preprocess-config';
+import processConfig from './process-config';
+import readConfig from './read-config';
+import validateConfig from './validate-config';
+import { getConfig } from './index';
+
+jest.mock('./read-config', () => ({
+    __esModule: true,
+    default: jest.fn(() => ({ config: 'readConfigResult', filePath: 'abc' })),
+}));
+
+jest.mock('./preprocess-config', () => ({
+    __esModule: true,
+    default: jest.fn(() => 'preprocessResult'),
+}));
+
+jest.mock('./validate-config', () => ({
+    __esModule: true,
+    default: jest.fn(() => 'validateResult'),
+}));
+
+jest.mock('./process-config', () => ({
+    __esModule: true,
+    default: jest.fn(() => 'processResult'),
+}));
+
+describe('getConfig', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+    it('should read config', () => {
+        getConfig('configPath');
+        expect(readConfig).toHaveBeenCalledTimes(1);
+        expect(readConfig).toHaveBeenCalledWith('configPath');
+    });
+    it('should then preprocess config if config is found', () => {
+        getConfig('configPath');
+        expect(preprocessConfig).toHaveBeenCalledTimes(1);
+        expect(preprocessConfig).toHaveBeenCalledWith({
+            config: 'readConfigResult',
+            filePath: 'abc',
+        });
+    });
+    it('should not preprocess config if no config is found', () => {
+        (readConfig as any).mockImplementationOnce(() => ({}));
+        getConfig('configPath');
+        expect(preprocessConfig).toHaveBeenCalledTimes(0);
+    });
+    it('should then validate config', () => {
+        getConfig('configPath');
+        expect(validateConfig).toHaveBeenCalledTimes(1);
+        expect(validateConfig).toHaveBeenCalledWith({
+            filePath: 'abc',
+            config: 'preprocessResult',
+        });
+    });
+    it('should then return the processed config', () => {
+        const config = getConfig('configPath');
+        expect(processConfig).toHaveBeenCalledTimes(1);
+        expect(processConfig).toHaveBeenCalledWith({
+            filePath: 'abc',
+            config: 'preprocessResult',
+        });
+        expect(config).toBe('processResult');
+    });
+    it('should throw if config validation fails', () => {
+        (readConfig as any).mockImplementationOnce(() => {
+            throw new Error('foo');
+        });
+        expect(() => {
+            getConfig('configPath');
+        }).toThrow('foo');
+    });
+});

--- a/src/config/validate-config.test.ts
+++ b/src/config/validate-config.test.ts
@@ -21,4 +21,25 @@ describe('validateConfig', () => {
             validateConfig({ config: {} });
         }).toThrow();
     });
+
+    it('throws if unpreprocessed rule functions are passed', () => {
+        expect(() => {
+            validateConfig({
+                config: {
+                    root: 'src',
+                    rules: {},
+                },
+            });
+        }).not.toThrow();
+        expect(() => {
+            validateConfig({
+                config: {
+                    root: 'src',
+                    rules: {
+                        abc: () => ({}),
+                    },
+                },
+            });
+        }).toThrow();
+    });
 });

--- a/src/config/validate-config.ts
+++ b/src/config/validate-config.ts
@@ -1,8 +1,7 @@
 import ajv from 'ajv';
 import * as schema from './config-schema.json';
-import { ValidatedConfigFile } from '../types';
 
-export default (foundConfig: any): foundConfig is ValidatedConfigFile => {
+export default (foundConfig: any): void => {
     if (!foundConfig) {
         throw new Error('No config found');
     }
@@ -22,6 +21,4 @@ export default (foundConfig: any): foundConfig is ValidatedConfigFile => {
     if (!valid && validate.errors) {
         throw new Error(`Invalid config: ${JSON.stringify(validate.errors, null, 2)}`);
     }
-
-    return true;
 };

--- a/src/config/validate-config.ts
+++ b/src/config/validate-config.ts
@@ -1,7 +1,8 @@
 import ajv from 'ajv';
 import * as schema from './config-schema.json';
+import { ValidatedConfigFile } from '../types';
 
-export default (foundConfig: any): void => {
+export default (foundConfig: any): foundConfig is ValidatedConfigFile => {
     if (!foundConfig) {
         throw new Error('No config found');
     }
@@ -21,4 +22,6 @@ export default (foundConfig: any): void => {
     if (!valid && validate.errors) {
         throw new Error(`Invalid config: ${JSON.stringify(validate.errors, null, 2)}`);
     }
+
+    return true;
 };

--- a/src/integration-tests/stricter.test.ts
+++ b/src/integration-tests/stricter.test.ts
@@ -130,19 +130,20 @@ describe('Stricter', () => {
         expect(console.log).toHaveBeenNthCalledWith(3, '2 errors');
     });
 
-    it('should work with rules config function', () => {
+    it('should work with rules functions', () => {
         jest.doMock(stricterConfigPath, () => ({
             root: 'project/src',
             rulesDir: 'project/rules',
             exclude: [/.*\.json/],
-            rules: ({ packages }: { packages: string[] }) => ({
-                'stricter/unused-files': packages.map((pkg: string) => ({
-                    level: 'error',
-                    config: {
-                        entry: [new RegExp(`${pkg}/index.js`)],
-                    },
-                })),
-            }),
+            rules: {
+                'stricter/unused-files': ({ packages }: { packages: string[] }) =>
+                    packages.map((pkg: string) => ({
+                        level: 'error',
+                        config: {
+                            entry: [new RegExp(`${pkg}/index.js`)],
+                        },
+                    })),
+            },
         }));
         const stricter = getStricter({
             config: stricterConfigPath,
@@ -152,7 +153,6 @@ describe('Stricter', () => {
         });
 
         stricter();
-        expect(console.log).toHaveBeenCalledTimes(5);
         expect(console.log).toHaveBeenNthCalledWith(
             1,
             expect.stringMatching(
@@ -178,6 +178,7 @@ describe('Stricter', () => {
             ),
         );
         expect(console.log).toHaveBeenNthCalledWith(5, '4 errors');
+        expect(console.log).toHaveBeenCalledTimes(5);
     });
 
     it('should work with rules config function and custom packages array', () => {
@@ -185,14 +186,15 @@ describe('Stricter', () => {
             root: 'project/src',
             rulesDir: 'project/rules',
             exclude: [/.*\.json/],
-            rules: ({ packages }: { packages: string[] }) => ({
-                'stricter/unused-files': packages.map((pkg: string) => ({
-                    level: 'error',
-                    config: {
-                        entry: [new RegExp(`${pkg}/index.js`)],
-                    },
-                })),
-            }),
+            rules: {
+                'stricter/unused-files': ({ packages }: { packages: string[] }) =>
+                    packages.map((pkg: string) => ({
+                        level: 'error',
+                        config: {
+                            entry: [new RegExp(`${pkg}/index.js`)],
+                        },
+                    })),
+            },
             packages: ['f*'],
         }));
         const stricter = getStricter({
@@ -203,7 +205,6 @@ describe('Stricter', () => {
         });
 
         stricter();
-        expect(console.log).toHaveBeenCalledTimes(3);
         expect(console.log).toHaveBeenNthCalledWith(
             1,
             expect.stringMatching(
@@ -217,6 +218,7 @@ describe('Stricter', () => {
             ),
         );
         expect(console.log).toHaveBeenNthCalledWith(3, '2 errors');
+        expect(console.log).toHaveBeenCalledTimes(3);
     });
 
     describe('plugins', () => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,6 +3,10 @@ export interface ConfigFile {
     config: ConfigAPI;
 }
 
+export interface ValidatedConfigFile extends ConfigFile {
+    config: Config;
+}
+
 export enum Level {
     WARNING = 'warning',
     ERROR = 'error',
@@ -30,6 +34,12 @@ export interface RuleUsage {
     config?: RuleUsageConfig;
 }
 
+export type RuleFn = (args: { packages: string[] }) => RuleUsage | RuleUsage[];
+
+export interface ConfigRulesAPI {
+    [ruleName: string]: RuleUsage | RuleUsage[] | RuleFn;
+}
+
 export interface ConfigRules {
     [ruleName: string]: RuleUsage | RuleUsage[];
 }
@@ -40,13 +50,11 @@ export interface Plugin {
     };
 }
 
-export type ConfigRulesFn = (args: { packages: string[] }) => ConfigRules;
-
 export interface ConfigAPI {
     root: string;
     rulesDir?: string | string[];
     exclude?: FileFilter;
-    rules: ConfigRules | ConfigRulesFn;
+    rules: ConfigRulesAPI;
     plugins?: string[];
     packages?: string[];
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -130,3 +130,6 @@ export const getHashFunction = (): HashFunction => {
             .digest()
             .toString(16);
 };
+
+export const getDirResolver = (filepath: string) => (dir: string) =>
+    path.resolve(path.dirname(filepath), dir);

--- a/src/utils/test.ts
+++ b/src/utils/test.ts
@@ -1,4 +1,4 @@
-import { readFile, listFiles, parse } from '.';
+import { readFile, listFiles, parse, getDirResolver } from '.';
 
 jest.mock('fs');
 jest.mock('path');
@@ -175,5 +175,30 @@ describe('parse', () => {
         expect(parseMock.mock.calls.length).toBe(1);
         expect(parseMock.mock.calls[0][0]).toBe(src);
         expect(result).toBe(src);
+    });
+});
+
+describe('getDirResolver', () => {
+    const mockDirname = 'mockDirname';
+
+    beforeAll(() => {
+        const { dirname, resolve } = require('path');
+
+        dirname.mockImplementation((dirName: string) => {
+            if (dirName === mockDirname) {
+                return mockDirname;
+            }
+        });
+        resolve.mockImplementation((dirName: string, dir: string) => {
+            if (dirName === mockDirname) {
+                return dir;
+            }
+        });
+    });
+
+    it('resolves files relative to mockDirName', () => {
+        const dirResolver = getDirResolver(mockDirname);
+
+        expect(dirResolver('test')).toBe('test');
     });
 });


### PR DESCRIPTION
Move rules function API from rules field to each rule usage.

It is more flexible for each rule to be able to be configured as a
function rather than relying on the `rules` field itself to be one. In
particular, this makes it easier to use third party shareable configs
that rely on rule functions for package-level rules.

This additionally moves the rules function processing to a
pre-processing step so that the resulting rule usages can be validated.