### PR TITLE
Fix --config resolving

### DIFF
--- a/src/factory/get-config-location.test.ts
+++ b/src/factory/get-config-location.test.ts
@@ -17,7 +17,7 @@ describe('getConfigLocation', () => {
     it('returns relative path if exists', () => {
         const currentPath = 'cwd';
         const configPath = 'configPath.js';
-        existsSync.mockReturnValueOnce(false).mockReturnValueOnce(true);
+        existsSync.mockReturnValueOnce(true);
         const result = getConfigLocation(currentPath, configPath);
 
         expect(result).toBe(path.join(currentPath, configPath));
@@ -25,7 +25,7 @@ describe('getConfigLocation', () => {
 
     it('throws if path is not found', () => {
         expect(() => {
-            existsSync.mockReturnValueOnce(false).mockReturnValueOnce(false);
+            existsSync.mockReturnValueOnce(false);
             getConfigLocation('', 'some-config');
         }).toThrow(/Could not find config file at/);
     });

--- a/src/factory/get-config-location.ts
+++ b/src/factory/get-config-location.ts
@@ -5,16 +5,12 @@ export const configFile = 'stricter.config.js';
 
 export const getConfigLocation = (currentPath: string, configPath?: string): string => {
     if (configPath) {
-        if (fs.existsSync(configPath)) {
-            return configPath;
-        }
-
         const relativePath = path.join(currentPath, configPath);
         if (fs.existsSync(relativePath)) {
             return relativePath;
         }
 
-        throw new Error(`Could not find config file at ${configPath}`);
+        throw new Error(`Could not find config file at ${relativePath}`);
     }
 
     let dir = currentPath;

--- a/src/factory/index.ts
+++ b/src/factory/index.ts
@@ -1,4 +1,4 @@
-import * as isCi from 'is-ci';
+import isCi from 'is-ci';
 import { stricter } from '../stricter';
 import { logger as getDebugLogger } from '../logger/get-debug-logger';
 import { logger as getNullLogger } from '../logger/get-null-logger';


### PR DESCRIPTION
Stricter CLI exposes the `-c` and `--config` flags, similar to ESLint, however they weren't functional.

The default behaviour of not specifying a config path correctly finds the root config, but when specifying a path it'd throw an error claiming to not find the file.

Additionally, fixes an import to fix allow opting into the debug logger.

`const logger = isCi ? getNullLogger() : getDebugLogger();`

